### PR TITLE
Rename package from libstone to libstone-go

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,7 @@ tasks:
 
   build:
     cmds:
-      - go build -o {{.OUTPATH}} -ldflags "-X github.com/serpent-os/libstone/internal/cli.Version={{.VERSION}}" cli/main.go
+      - go build -o {{.OUTPATH}} -ldflags "-X github.com/serpent-os/libstone-go/internal/cli.Version={{.VERSION}}" cli/main.go
     vars:
       VERSION:
         sh: git describe --tags || git rev-parse HEAD

--- a/cli/main.go
+++ b/cli/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/serpent-os/libstone/internal/cli"
+	"github.com/serpent-os/libstone-go/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Serpent OS Developers
 // SPDX-License-Identifier: MPL-2.0
 
-module github.com/serpent-os/libstone
+module github.com/serpent-os/libstone-go
 
 go 1.21
 

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"unicode/utf8"
 
-	"github.com/serpent-os/libstone"
-	"github.com/serpent-os/libstone/stone1"
+	"github.com/serpent-os/libstone-go"
+	"github.com/serpent-os/libstone-go/stone1"
 )
 
 type cmdInspect struct {

--- a/internal/readers/bytewalker_test.go
+++ b/internal/readers/bytewalker_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/serpent-os/libstone/internal/readers"
+	"github.com/serpent-os/libstone-go/internal/readers"
 )
 
 const (

--- a/prelude.go
+++ b/prelude.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/serpent-os/libstone/internal/readers"
+	"github.com/serpent-os/libstone-go/internal/readers"
 )
 
 // Version is the stone format version contained inside the [Prelude].

--- a/stone1/payload.go
+++ b/stone1/payload.go
@@ -4,7 +4,7 @@
 package stone1
 
 import (
-	"github.com/serpent-os/libstone/internal/readers"
+	"github.com/serpent-os/libstone-go/internal/readers"
 )
 
 // RecordKind is the kind of the payload's records.

--- a/stone1/prelude.go
+++ b/stone1/prelude.go
@@ -6,8 +6,8 @@ package stone1
 import (
 	"errors"
 
-	"github.com/serpent-os/libstone"
-	"github.com/serpent-os/libstone/internal/readers"
+	"github.com/serpent-os/libstone-go"
+	"github.com/serpent-os/libstone-go/internal/readers"
 )
 
 var (

--- a/stone1/record.go
+++ b/stone1/record.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"io/fs"
 
-	"github.com/serpent-os/libstone/internal/readers"
+	"github.com/serpent-os/libstone-go/internal/readers"
 	"github.com/zeebo/xxh3"
 )
 


### PR DESCRIPTION
@der-eismann you were right, it's better to reflect the URL in the package name, otherwise pkg.go.dev won't find our library.

Furthermore, Go removes the `go-` prefix from package names. Now we have that string suffixed, let's see what happens.